### PR TITLE
Add InMemoryLocaleStore

### DIFF
--- a/library/src/main/java/com/yariksoffice/lingver/store/InMemoryLocaleStore.kt
+++ b/library/src/main/java/com/yariksoffice/lingver/store/InMemoryLocaleStore.kt
@@ -1,0 +1,44 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright 2019 Yaroslav Berezanskyi
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.yariksoffice.lingver.store
+
+import java.util.*
+
+/**
+ * Implementation of [LocaleStore] that keeps the current locale value in memory.
+ *
+ * Useful for cases like instrumentation tests, where you don't want to persist any changes
+ * to the application locale.
+ */
+class InMemoryLocaleStore() : LocaleStore {
+
+    private var locale: Locale = Locale.getDefault();
+
+    override fun getLocale(): Locale = locale
+
+    override fun persistLocale(locale: Locale) {
+        this.locale = locale
+    }
+}


### PR DESCRIPTION
For instrumentation tests, it's useful to be able to
change the application's locale to test various scenarios
but we don't want to persist the locale changes across
app restarts. This commit adds an in-memory implementation
of the LocaleStore interface that can be used for this
instrumentation test use case.